### PR TITLE
charging power and time

### DIFF
--- a/polestar-small-widget.js
+++ b/polestar-small-widget.js
@@ -85,7 +85,7 @@ async function createPolestarWidget(batteryData, odometerData, vehicle) {
     "CHARGER_CONNECTION_STATUS_CONNECTED";
   const chargingAmps = batteryData.chargingCurrentAmps ?? 0;
   const chargingWatts = batteryData.chargingPowerWatts ?? 0;
-  const chargingKw = parseInt(chargingWatts / 1000);
+  const chargingKw = Math.round(chargingWatts/100.0)/10.0; // convert to kW and round to 1 decimal
 
   // Prepare image
   if (!vehicle.content.images.studio.angles.includes(IMAGE_ANGLE)) {
@@ -159,9 +159,15 @@ async function createPolestarWidget(batteryData, odometerData, vehicle) {
     const batteryChargingTimeStack = batteryInfoStack.addStack();
     const remainingChargeTimeHours = parseInt(remainingChargingTime / 60);
     const remainingChargeTimeMinsRemainder = remainingChargingTime % 60;
+    const fraction = ({ 15: "¼", 30: "½", 45: "¾" })[remainingChargeTimeMinsRemainder] || "";
+    const timeStr =
+      remainingChargingTime >= 120
+        ? `${remainingChargeTimeHours}h`
+        : remainingChargingTime >= 60
+          ? `${remainingChargeTimeHours}${fraction}h`
+          : `${remainingChargeTimeMinsRemainder}m`;
     const chargingTimeElement = batteryChargingTimeStack.addText(
-      `${chargingKw} kW  -  ${remainingChargeTimeHours}h ${remainingChargeTimeMinsRemainder}m`
-    );
+      `${chargingKw} kW  -  ${timeStr}`);
     chargingTimeElement.font = Font.mediumSystemFont(10);
     chargingTimeElement.textOpacity = 0.9;
     chargingTimeElement.textColor = DARK_MODE ? Color.white() : Color.black();


### PR DESCRIPTION
- power rounded and with 1 decimal
- remaining time is in steps of 1h if >=120 min (>= 60 min: 15 min steps; < 60 min: 5 min steps)


Examples (with comparison to medium widget)
![IMG_1660](https://github.com/user-attachments/assets/2548a23b-e55b-415d-a447-177e5d3e7158)
![IMG_1661](https://github.com/user-attachments/assets/f1fbde60-84d0-4316-a394-5fe77ac206bf)
![IMG_2321](https://github.com/user-attachments/assets/1326734a-b98f-4f7f-8905-0335692eefe9)
![IMG_2456](https://github.com/user-attachments/assets/9e715eb4-70da-421b-898b-e3bba24690e2)
